### PR TITLE
MIC-7956: Fix Tinkoff Pay button availability on recurrent payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+
+* [MIC-7956] Fix Tinkoff Pay button availability on recurrent payments
+
 ## [2.16.0] - 2023-01-19Z
 
 ### Added

--- a/TinkoffASDKUI/TinkoffASDKUI/Modules/AcquiringPayment/View/AcquiringPaymentViewController.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/Modules/AcquiringPayment/View/AcquiringPaymentViewController.swift
@@ -305,12 +305,9 @@ class AcquiringPaymentViewController: PopUpViewContoller {
             tableViewCells.append(.qrCodeStatic(qrCode: qrCode, title: title))
 
         case .paymentWainingCVC:
-            userTableViewCells.forEach { item in
-                if case AcquiringViewTableViewCells.buttonPaySBP = item {
-                } else {
-                    tableViewCells.append(item)
-                }
-            }
+            userTableViewCells
+                .filter { !$0.isSBP && !$0.isTinkoffPay }
+                .forEach { tableViewCells.append($0) }
 
             tableViewCells.append(.cardList)
             tableViewCells.append(.buttonPay)
@@ -815,5 +812,23 @@ private extension AcquiringViewTableViewCells {
         }
 
         return true
+    }
+
+    var isSBP: Bool {
+        switch self {
+        case .buttonPaySBP:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isTinkoffPay: Bool {
+        switch self {
+        case .tinkoffPay:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
@@ -1256,7 +1256,6 @@ public class AcquiringUISDK: NSObject {
                                 data.savingAsParentPayment = true
                                 DispatchQueue.main.async {
                                     var chargePaymentId = successInitResponse.paymentId
-
                                     self.presentAcquiringPaymentView(
                                         presentingViewController: presentingViewController,
                                         customerKey: paymentData.customerKey,

--- a/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
@@ -1256,6 +1256,12 @@ public class AcquiringUISDK: NSObject {
                                 data.savingAsParentPayment = true
                                 DispatchQueue.main.async {
                                     var chargePaymentId = successInitResponse.paymentId
+
+                                    // На экране подтверждения CVC кода при рекуррентном платеже не может и не должна располагаться кнопка `TinkoffPay`
+                                    // Временное решение, исправляющее баг. Экран ввода cvc будет полностью переписан в ASDK v3
+                                    var configuration = configuration
+                                    configuration.featuresOptions.tinkoffPayEnabled = false
+
                                     self.presentAcquiringPaymentView(
                                         presentingViewController: presentingViewController,
                                         customerKey: paymentData.customerKey,

--- a/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
@@ -1257,15 +1257,10 @@ public class AcquiringUISDK: NSObject {
                                 DispatchQueue.main.async {
                                     var chargePaymentId = successInitResponse.paymentId
 
-                                    // На экране подтверждения CVC кода при рекуррентном платеже не может и не должна располагаться кнопка `TinkoffPay`
-                                    // Временное решение, исправляющее баг. Экран ввода cvc будет полностью переписан в ASDK v3
-                                    var modifiedConfiguration = configuration
-                                    modifiedConfiguration.featuresOptions.tinkoffPayEnabled = false
-
                                     self.presentAcquiringPaymentView(
                                         presentingViewController: presentingViewController,
                                         customerKey: paymentData.customerKey,
-                                        configuration: modifiedConfiguration
+                                        configuration: configuration
                                     ) { _ in
                                         self.acquiringView?.changedStatus(.initWaiting)
                                         self.initPay(paymentData: data, completionHandler: { initResponse in

--- a/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/SDK/AcquiringUISDK.swift
@@ -1259,13 +1259,13 @@ public class AcquiringUISDK: NSObject {
 
                                     // На экране подтверждения CVC кода при рекуррентном платеже не может и не должна располагаться кнопка `TinkoffPay`
                                     // Временное решение, исправляющее баг. Экран ввода cvc будет полностью переписан в ASDK v3
-                                    var configuration = configuration
-                                    configuration.featuresOptions.tinkoffPayEnabled = false
+                                    var modifiedConfiguration = configuration
+                                    modifiedConfiguration.featuresOptions.tinkoffPayEnabled = false
 
                                     self.presentAcquiringPaymentView(
                                         presentingViewController: presentingViewController,
                                         customerKey: paymentData.customerKey,
-                                        configuration: configuration
+                                        configuration: modifiedConfiguration
                                     ) { _ in
                                         self.acquiringView?.changedStatus(.initWaiting)
                                         self.initPay(paymentData: data, completionHandler: { initResponse in


### PR DESCRIPTION
Убрал отрисовку кнопки `TinkoffPay` на экране подтверждения cvc кода при рекуррентном платеже